### PR TITLE
Add Mechanic keys to info.plist

### DIFF
--- a/hTools2.roboFontExt/info.plist
+++ b/hTools2.roboFontExt/info.plist
@@ -26,5 +26,9 @@
 	<real>1395377116.056946</real>
 	<key>version</key>
 	<string>1.6</string>
+	<key>repository</key>
+	<string>gferreira/hTools2_extension</string>
+	<key>extensionPath</key>
+	<string>hTools2.roboFontExt</string>
 </dict>
 </plist>


### PR DESCRIPTION
This changes adds two keys that would allow hTools2 to be installed with Mechanic: https://github.com/jackjennings/Mechanic
