### PR TITLE
Update repository key for new repository location

### DIFF
--- a/hTools2.roboFontExt/info.plist
+++ b/hTools2.roboFontExt/info.plist
@@ -17,7 +17,7 @@
 	<key>name</key>
 	<string>hTools2</string>
 	<key>repository</key>
-	<string>gferreira/hTools2</string>
+	<string>gferreira/hTools2_extension</string>
 	<key>requiresVersionMajor</key>
 	<string>1</string>
 	<key>requiresVersionMinor</key>


### PR DESCRIPTION
I got a bug report that included some debugging text indicating Mechanic was looking in the old repository for updates.
